### PR TITLE
Make dev settings a little closer to production and document ubuntu setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ root = Page.objects.first()
 home = root.add_child(instance=HomePage(title='UWCS Home', slug='home', description='UWCS Home', show_in_menus=True))
 home.add_child(instance=AboutPage(title='Home', slug='home', show_in_menus=True))
 home.add_child(instance=EventsIndexPage(title='Events', slug='events', show_in_menus=True))
-Site.objects.create(hostname='localhost', port=80, root_page=home, site_name='local', is_default_site=True)
+Site.objects.create(hostname='localhost', port=8000, root_page=home, site_name='local', is_default_site=True)
 ```
 
 Start development server:

--- a/zarya/settings/base.py
+++ b/zarya/settings/base.py
@@ -177,3 +177,11 @@ WAGTAIL_SITE_NAME = 'UWCS (Zarya)'
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = 'uwcs.co.uk'
+
+# Celery
+BROKER_URL = 'redis://localhost:6379'
+CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+CELERY_ACCEPT_CONTENT = ['application/json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_TIMEZONE = 'GMT'

--- a/zarya/settings/dev.py
+++ b/zarya/settings/dev.py
@@ -10,13 +10,13 @@ SECRET_KEY = 'l33th4x0rs'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    },
-    # 'old_data': {
-    #     'ENGINE': 'django.db.backends.sqlite3',
-    #     'NAME': os.path.join(BASE_DIR, 'old_data.sqlite3'),
-    # }
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'zarya',
+        'USER': 'zarya',
+        'PASSWORD': 'password',
+        'HOST': 'localhost',
+        'PORT': '5432',
+    }
 }
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/zarya/settings/production.py.example
+++ b/zarya/settings/production.py.example
@@ -19,14 +19,6 @@ try:
 except ImportError:
     pass
 
-# Celery
-BROKER_URL = 'redis://localhost:6379'
-CELERY_RESULT_BACKEND = 'redis://localhost:6379'
-CELERY_ACCEPT_CONTENT = ['application/json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-CELERY_TIMEZONE = 'GMT'
-
 # LDAP
 LDAP_URL = 'ldap://localhost'
 LDAP_PORT = 389


### PR DESCRIPTION
Hi! I was curious to have a look at a modern django codebase, having not touched one for years now.

I had a go at setting up the zarya site (in a development rather than production manner) and thought it could be handy in case anyone you know is interested in contributing. I changed the default development settings in order to use Postgres/Redis by default.

Not so sure about the bower step, I see that there is a django_bower package in the requirements file but I don't know if that replaces the steps I took.