### PR TITLE
Use BST aware timezone.

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -25,6 +25,12 @@ class EventFeed(ICalFeed):
     def item_start_datetime(self, item):
         return item.start
 
+    def item_end_datetime(self, item):
+        return item.finish
+
+    def item_location(self, item):
+        return item.location
+
     def item_link(self, item):
         return 'https://uwcs.co.uk' + item.get_url_parts()[2]
 

--- a/zarya/settings/base.py
+++ b/zarya/settings/base.py
@@ -110,7 +110,7 @@ DATABASES = {
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 LANGUAGE_CODE = 'en-gb'
 
-TIME_ZONE = 'GMT'
+TIME_ZONE = 'Europe/London'
 
 USE_I18N = True
 


### PR DESCRIPTION
I believe this fixes the issue where the ical events are off by 1.

GMT is the same as UTC (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones )

E.g. user would create an event selecting start time as 6pm October 14th. Django would assume they wanted 6pm GMT (UTC). When the ical file is imported, calendar software understands that the 6pm GMT on Oct 14th is 7pm local time on the 14th.

With this setting, times are still stored as UTC in postgres, but when you enter 6pm when creating an event, it gets translated to 5pm UTC.

There are presumably existing events that will need their times fixing due to the bug described above.